### PR TITLE
Various fixes to stopping a run early

### DIFF
--- a/src/main/java/com/roosterteeth/Main.java
+++ b/src/main/java/com/roosterteeth/Main.java
@@ -243,6 +243,15 @@ public class Main {
                     throw new RuntimeException(e);
                 }
             }
+
+            List<File> outputFiles = new ArrayList<>();
+            for(int i = 0; i < numWorkers; i++) {
+                final String outputPath = System.getProperty("user.dir") + File.separatorChar + "archives"
+                        + File.separatorChar + archiveName + File.separatorChar + "output_worker_"+ i + ".json";
+                new File(outputPath).delete();
+            }
+
+
             LogUtility.logInfo("Workers have finished!");
             //get results from workers
             HashSet<String> unarchivedFoundPages = new HashSet<>();

--- a/src/main/java/com/roosterteeth/hooks/WorkerShutdownHook.java
+++ b/src/main/java/com/roosterteeth/hooks/WorkerShutdownHook.java
@@ -31,9 +31,6 @@ public class WorkerShutdownHook extends Thread {
         LogUtility.logInfo("Worker has archived: " + worker.hasArchived());
         if(!worker.hasArchived()){
             LogUtility.logInfo("Worker shutting down...");
-            worker.switchToHandle(archiveIndexHandle);
-            worker.endArchiving();
-
             JSONObject results = new JSONObject();
             JSONArray seedsArray = new JSONArray();
             seedsArray.addAll(worker.getFoundUnarchivedURLS());
@@ -62,6 +59,9 @@ public class WorkerShutdownHook extends Thread {
                 LogUtility.logError("Error writing to file: " + e.getMessage());
                 throw new RuntimeException(e);
             }
+
+            worker.switchToHandle(archiveIndexHandle);
+            worker.endArchiving();
         }
     }
 }

--- a/src/main/java/com/roosterteeth/worker/ArchiveWorker.java
+++ b/src/main/java/com/roosterteeth/worker/ArchiveWorker.java
@@ -6,6 +6,8 @@ import com.roosterteeth.pages.RoosterteethPage;
 import com.roosterteeth.pages.RoosterteethPageFactory;
 import com.roosterteeth.utility.LogUtility;
 import com.roosterteeth.utility.WaitHelper;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -13,6 +15,8 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -224,6 +228,35 @@ public class ArchiveWorker implements Runnable,IArchiveWorker{
         }
         driver.switchTo().window(archiveIndexHandle);
         endArchiving();
+
+        JSONObject results = new JSONObject();
+        JSONArray seedsArray = new JSONArray();
+        seedsArray.addAll(getFoundUnarchivedURLS());
+
+        JSONArray completed = new JSONArray();
+        completed.addAll(getFoundUnarchivedURLS());
+
+        JSONArray failedArray = new JSONArray();
+        failedArray.addAll(getFailedURLS());
+
+        JSONArray excludedArray = new JSONArray();
+        excludedArray.addAll(getExcludedURLS());
+
+        results.put("seeds", seedsArray);
+        results.put("completed", completed);
+        results.put("exclude", excludedArray);
+        results.put("failed", failedArray);
+
+        FileWriter file = null;
+        try {
+            file = new FileWriter( System.getProperty("user.dir") + File.separatorChar + "archives"
+                    + File.separatorChar + archiveName + File.separatorChar + "output_worker_"+ getID() + ".json");
+            file.write(results.toJSONString());
+            file.close();
+        } catch (IOException e) {
+            LogUtility.logError("Error writing to file: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
     }
 
     public void switchToHandle(String handle){


### PR DESCRIPTION
Workers should now create output jsons if completed normally, and before downloading in case of shutdown hook. This will allow the overall shutdown hook to create a complete output.json for the run.